### PR TITLE
Add `--rename` option for renaming fields

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -206,6 +206,8 @@ These type classes accept the following options:
   with `--prefix person` the field name `personFirstName` would become
   `FirstName`.
 
+- `--suffix SUFFIX`: Same as `--prefix` except for suffixes.
+
 - `--title`: Convert field names into `TitleCase`. For example `firstName`
   would become `FirstName`.
 

--- a/README.markdown
+++ b/README.markdown
@@ -211,6 +211,11 @@ These type classes accept the following options:
 - `--title`: Convert field names into `TitleCase`. For example `firstName`
   would become `FirstName`.
 
+- `--rename OLD:NEW`: Renames the given `OLD` field into the given `NEW` one.
+  This can be useful to use keywords as field names. For example,
+  `--rename type_:type` will change a field called `type_` into a field called
+  `type`.
+
 Options are processed in order. So for example `--prefix person --kebab` would
 change `personFirstName` into `first-name`.
 

--- a/README.markdown
+++ b/README.markdown
@@ -196,20 +196,20 @@ These type classes accept the following options:
   would become `first-name`.
 
 - `--camel`: Convert field names into `camelCase`. For example `FirstName`
-  would become `firstName`. This is usually combined with `--strip PREFIX`.
+  would become `firstName`. This is usually combined with `--prefix PREFIX`.
 
 - `--snake`: Convert field names into `snake_case`. For example `firstName`
   would become `first_name`.
 
-- `--strip PREFIX`: Removes the given prefix from field names. If the field
+- `--prefix PREFIX`: Removes the given prefix from field names. If the field
   name doesn't begin with the prefix, an error will be thrown. For example,
-  with `--strip person` the field name `personFirstName` would become
+  with `--prefix person` the field name `personFirstName` would become
   `FirstName`.
 
 - `--title`: Convert field names into `TitleCase`. For example `firstName`
   would become `FirstName`.
 
-Options are processed in order. So for example `--strip person --kebab` would
+Options are processed in order. So for example `--prefix person --kebab` would
 change `personFirstName` into `first-name`.
 
 ### Arbitrary

--- a/evoke.cabal
+++ b/evoke.cabal
@@ -20,6 +20,7 @@ library
   build-depends:
     base >= 4.14 && < 4.15
     , ghc >= 8.10.1 && < 8.11
+    , text >= 1.2.3 && < 1.3
   default-language: Haskell2010
   exposed-modules:
     Evoke

--- a/evoke.cabal
+++ b/evoke.cabal
@@ -20,7 +20,7 @@ library
   build-depends:
     base >= 4.14 && < 4.15
     , ghc >= 8.10.1 && < 8.11
-    , text >= 1.2.3 && < 1.3
+    , text >= 1.2.3 && < 1.3 || >= 2.0 && < 2.1
   default-language: Haskell2010
   exposed-modules:
     Evoke

--- a/src/lib/Evoke/Generator/Common.hs
+++ b/src/lib/Evoke/Generator/Common.hs
@@ -43,7 +43,7 @@ fieldNameOptions srcSpan =
   , Console.Option [] ["snake"] (Console.NoArg $ pure . snake) ""
   , Console.Option
     []
-    ["strip"]
+    ["prefix", "strip"]
     (Console.ReqArg
       (stripPrefix srcSpan)
       "PREFIX"

--- a/src/lib/Evoke/Generator/Common.hs
+++ b/src/lib/Evoke/Generator/Common.hs
@@ -45,20 +45,22 @@ fieldNameOptions srcSpan =
     []
     ["strip"]
     (Console.ReqArg
-      (\prefix s1 -> case List.stripPrefix prefix s1 of
-        Nothing ->
-          Hsc.throwError srcSpan
-            . Ghc.text
-            $ show prefix
-            <> " is not a prefix of "
-            <> show s1
-        Just s2 -> pure s2
-      )
+      (stripPrefix srcSpan)
       "PREFIX"
     )
     ""
   , Console.Option [] ["title"] (Console.NoArg $ pure . upper) ""
   ]
+
+stripPrefix :: Ghc.SrcSpan -> String -> String -> Ghc.Hsc String
+stripPrefix srcSpan prefix s1 = case List.stripPrefix prefix s1 of
+  Nothing ->
+    Hsc.throwError srcSpan
+      . Ghc.text
+      $ show prefix
+      <> " is not a prefix of "
+      <> show s1
+  Just s2 -> pure s2
 
 -- | Applies all the monadic functions in order beginning with some starting
 -- value.

--- a/src/lib/Evoke/Generator/Common.hs
+++ b/src/lib/Evoke/Generator/Common.hs
@@ -14,6 +14,7 @@ import qualified Data.Char as Char
 import qualified Data.IORef as IORef
 import qualified Data.List as List
 import qualified Data.Maybe as Maybe
+import qualified Data.Text as Text
 import qualified Evoke.Hs as Hs
 import qualified Evoke.Hsc as Hsc
 import qualified Evoke.Type.Constructor as Constructor
@@ -49,6 +50,14 @@ fieldNameOptions srcSpan =
       "PREFIX"
     )
     ""
+  , Console.Option
+    []
+    ["suffix"]
+    (Console.ReqArg
+      (stripSuffix srcSpan)
+      "SUFFIX"
+    )
+    ""
   , Console.Option [] ["title"] (Console.NoArg $ pure . upper) ""
   ]
 
@@ -61,6 +70,16 @@ stripPrefix srcSpan prefix s1 = case List.stripPrefix prefix s1 of
       <> " is not a prefix of "
       <> show s1
   Just s2 -> pure s2
+
+stripSuffix :: Ghc.SrcSpan -> String -> String -> Ghc.Hsc String
+stripSuffix srcSpan suffix s1 = case Text.stripSuffix (Text.pack suffix) (Text.pack s1) of
+  Nothing ->
+    Hsc.throwError srcSpan
+      . Ghc.text
+      $ show suffix
+      <> " is not a suffix of "
+      <> show s1
+  Just s2 -> pure $ Text.unpack s2
 
 -- | Applies all the monadic functions in order beginning with some starting
 -- value.

--- a/src/lib/Evoke/Generator/Common.hs
+++ b/src/lib/Evoke/Generator/Common.hs
@@ -42,22 +42,8 @@ fieldNameOptions srcSpan =
   [ Console.Option [] ["kebab"] (Console.NoArg $ pure . kebab) ""
   , Console.Option [] ["camel"] (Console.NoArg $ pure . lower) ""
   , Console.Option [] ["snake"] (Console.NoArg $ pure . snake) ""
-  , Console.Option
-    []
-    ["prefix", "strip"]
-    (Console.ReqArg
-      (stripPrefix srcSpan)
-      "PREFIX"
-    )
-    ""
-  , Console.Option
-    []
-    ["suffix"]
-    (Console.ReqArg
-      (stripSuffix srcSpan)
-      "SUFFIX"
-    )
-    ""
+  , Console.Option [] ["prefix", "strip"] (Console.ReqArg (stripPrefix srcSpan) "PREFIX" ) ""
+  , Console.Option [] ["suffix"] (Console.ReqArg (stripSuffix srcSpan) "SUFFIX" ) ""
   , Console.Option [] ["title"] (Console.NoArg $ pure . upper) ""
   ]
 

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -115,21 +115,21 @@ newtype T6 = T6C1
   { t6c1f1 :: Int
   }
   deriving (Eq, Show)
-  deriving (Arbitrary, FromJSON, ToJSON, ToSchema) via "Evoke --strip t6c1"
+  deriving (Arbitrary, FromJSON, ToJSON, ToSchema) via "Evoke --prefix t6c1"
 
 -- stripped then capitalized
 newtype T7 = T7C1
   { t7c1f1 :: Int
   }
   deriving (Eq, Show)
-  deriving (Arbitrary, FromJSON, ToJSON, ToSchema) via "Evoke --strip t7c1 --title"
+  deriving (Arbitrary, FromJSON, ToJSON, ToSchema) via "Evoke --prefix t7c1 --title"
 
 -- capitalized then stripped
 newtype T8 = T8C1
   { t8c1f1 :: Int
   }
   deriving (Eq, Show)
-  deriving (Arbitrary, FromJSON, ToJSON, ToSchema) via "Evoke --title --strip T8c1"
+  deriving (Arbitrary, FromJSON, ToJSON, ToSchema) via "Evoke --title --prefix T8c1"
 
 -- phantom type
 newtype T9 a = T9C1
@@ -150,7 +150,7 @@ newtype T11 = T11C1
   { t11c1f1A :: Int
   }
   deriving (Eq, Show)
-  deriving (Arbitrary, FromJSON, ToJSON, ToSchema) via "Evoke --strip t11c1f1 --camel"
+  deriving (Arbitrary, FromJSON, ToJSON, ToSchema) via "Evoke --prefix t11c1f1 --camel"
 
 -- multiple type variables
 data T12 a b c d e = T12C1

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -36,6 +36,7 @@ main = Unit.runTestTTAndExit $ Unit.test
     [Aeson.aesonQQ| { "t13c1f1": 15, "t13c1f2": 16 } |]
   , testToJSON T14C1 { t14c1f1 = Just 17 } [Aeson.aesonQQ| { "t14c1f1": 17 } |]
   , testToJSON T15C1 { t15c1f1 = 18 } [Aeson.aesonQQ| { "t15c1": 18 } |]
+  , testToJSON T16C1 { t16c1f1 = 19 } [Aeson.aesonQQ| { "one": 19 } |]
   , checkInstances (Proxy.Proxy :: Proxy.Proxy T1)
   , checkInstances (Proxy.Proxy :: Proxy.Proxy T2)
   , checkInstances (Proxy.Proxy :: Proxy.Proxy T3)
@@ -51,6 +52,7 @@ main = Unit.runTestTTAndExit $ Unit.test
   , checkInstances (Proxy.Proxy :: Proxy.Proxy T13)
   , checkInstances (Proxy.Proxy :: Proxy.Proxy T14)
   , checkInstances (Proxy.Proxy :: Proxy.Proxy T15)
+  , checkInstances (Proxy.Proxy :: Proxy.Proxy T16)
   ]
 
 checkInstances
@@ -182,3 +184,10 @@ newtype T15 = T15C1
   }
   deriving (Eq, Show)
   deriving (Arbitrary, FromJSON, ToJSON, ToSchema) via "Evoke --suffix f1"
+
+-- renamed
+newtype T16 = T16C1
+  { t16c1f1 :: Int
+  }
+  deriving (Eq, Show)
+  deriving (Arbitrary, FromJSON, ToJSON, ToSchema) via "Evoke --rename t16c1f1:one"

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -35,6 +35,7 @@ main = Unit.runTestTTAndExit $ Unit.test
     T13C1 { t13c1f1 = 15, t13c1f2 = 16 }
     [Aeson.aesonQQ| { "t13c1f1": 15, "t13c1f2": 16 } |]
   , testToJSON T14C1 { t14c1f1 = Just 17 } [Aeson.aesonQQ| { "t14c1f1": 17 } |]
+  , testToJSON T15C1 { t15c1f1 = 18 } [Aeson.aesonQQ| { "t15c1": 18 } |]
   , checkInstances (Proxy.Proxy :: Proxy.Proxy T1)
   , checkInstances (Proxy.Proxy :: Proxy.Proxy T2)
   , checkInstances (Proxy.Proxy :: Proxy.Proxy T3)
@@ -49,6 +50,7 @@ main = Unit.runTestTTAndExit $ Unit.test
   , checkInstances (Proxy.Proxy :: Proxy.Proxy (T12 X Int X Int X))
   , checkInstances (Proxy.Proxy :: Proxy.Proxy T13)
   , checkInstances (Proxy.Proxy :: Proxy.Proxy T14)
+  , checkInstances (Proxy.Proxy :: Proxy.Proxy T15)
   ]
 
 checkInstances
@@ -173,3 +175,10 @@ newtype T14 = T14C1
   }
   deriving (Eq, Show)
   deriving (Arbitrary, FromJSON, ToJSON, ToSchema) via "Evoke"
+
+-- stripped suffix
+newtype T15 = T15C1
+  { t15c1f1 :: Int
+  }
+  deriving (Eq, Show)
+  deriving (Arbitrary, FromJSON, ToJSON, ToSchema) via "Evoke --suffix f1"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-18.8
+resolver: lts-18.28


### PR DESCRIPTION
Fixes #2.

Also adds `--suffix` for stripping suffixes from fields. This is just like the old `--strip` option except that it works on suffixes instead of prefixes. 

Also adds a `--prefix` alias for the `--strip` option for symmetry with `--suffix`. In the future I'll probably remove the `--strip` option, but it'll hang around for a while. 